### PR TITLE
Bump up Postgress Engine to 14.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_security_group" "rds" {
 
 resource "aws_db_parameter_group" "education" {
   name   = "education"
-  family = "postgres13"
+  family = "postgres14"
 
   parameter {
     name  = "log_connections"
@@ -63,7 +63,7 @@ resource "aws_db_instance" "education" {
   instance_class         = "db.t3.micro"
   allocated_storage      = 5
   engine                 = "postgres"
-  engine_version         = "13.1"
+  engine_version         = "14.1"
   username               = "edu"
   password               = var.db_password
   db_subnet_group_name   = aws_db_subnet_group.education.name


### PR DESCRIPTION
It was error with 13.1 now: Error: Error creating DB Instance: InvalidParameterCombination: Cannot find version 13.1 for postgres
So after bump up to 14.1 - no errors.